### PR TITLE
Update notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.cache/
+.jupyter/
+.ipynb_checkpoints/
+.ipython/
+.keras/
+.local/
+keras_model_best.h5
+ntuple_merged_0.h5
+ntuple_merged_10.h5
+

--- a/README.rst
+++ b/README.rst
@@ -4,13 +4,12 @@
 HiggsToBBMachineLearning
 ==============================================================================
 
-|open-swan|
+|open-binder|
 
 Author: `Javier Duarte <https://orcid.org/0000-0002-5076-7096>`_
 
-.. |open-swan| image::  http://swanserver.web.cern.ch/swanserver/images/badge_swan_white_150.png
-    :target: https://cern.ch/swanserver/cgi-bin/go?projurl=https://github.com/cernopendata-datascience/HiggsToBBMachineLearning.git
-    :alt: Open in SWAN
+.. |open-binder| image:: https://mybinder.org/badge_logo.svg
+ :target: https://mybinder.org/v2/gh/cernopendata-datascience/HiggsToBBMachineLearning/master?filepath=train.ipynb
 
 Analysis structure
 ==================
@@ -18,9 +17,9 @@ Analysis structure
 1. Input data
 -------------
 
-Training and test HDF5 files from CMS ML open data release. 
+Training and test HDF5 files from CMS ML open data release.
 
-- http://opendata-dev.web.cern.ch/record/12102
+- http://opendata.cern.ch/record/12102
 
 
 2. Analysis code
@@ -45,7 +44,7 @@ Run example notebook:
 5. Output results
 -----------------
 
-Example ouput ROC curve from training 
+Example ouput ROC curve from training
 
 .. figure:: https://github.com/cernopendata-datascience/HiggsToBBMachineLearning/raw/master/ROC.png
    :alt: ROC.png

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,10 @@
+name: analysis
+channels:
+    - conda-forge
+dependencies:
+    - root=6.16.00
+    - keras
+    - tensorflow
+    - pytables
+    - scikit-learn
+    - matplotlib

--- a/train.ipynb
+++ b/train.ipynb
@@ -2,57 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Collecting tables\n",
-      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/75/73/d941a2ad1427572a1c9689ece4a3ada627e47c8e8e809ff336d2745cac42/tables-3.5.1-cp27-cp27mu-manylinux1_x86_64.whl (4.3MB)\n",
-      "\u001b[K    100% |████████████████████████████████| 4.3MB 6.4MB/s eta 0:00:01\n",
-      "\u001b[?25hRequirement already satisfied: six>=1.9.0 in /cvmfs/sft.cern.ch/lcg/views/LCG_95a/x86_64-centos7-gcc7-opt/lib/python2.7/site-packages (from tables) (1.11.0)\n",
-      "Requirement already satisfied: mock>=2.0 in /cvmfs/sft.cern.ch/lcg/views/LCG_95a/x86_64-centos7-gcc7-opt/lib/python2.7/site-packages (from tables) (2.0.0)\n",
-      "Requirement already satisfied: numpy>=1.9.3 in /cvmfs/sft.cern.ch/lcg/views/LCG_95a/x86_64-centos7-gcc7-opt/lib/python2.7/site-packages (from tables) (1.14.2)\n",
-      "Requirement already satisfied: numexpr>=2.6.2 in /cvmfs/sft.cern.ch/lcg/views/LCG_95a/x86_64-centos7-gcc7-opt/lib/python2.7/site-packages (from tables) (2.6.6)\n",
-      "Requirement already satisfied: funcsigs>=1 in /cvmfs/sft.cern.ch/lcg/views/LCG_95a/x86_64-centos7-gcc7-opt/lib/python2.7/site-packages (from mock>=2.0->tables) (1.0.2)\n",
-      "Requirement already satisfied: pbr>=0.11 in /cvmfs/sft.cern.ch/lcg/views/LCG_95a/x86_64-centos7-gcc7-opt/lib/python2.7/site-packages (from mock>=2.0->tables) (4.1.1)\n",
-      "\u001b[31mtensorflow 1.12.0 requires backports.weakref>=1.0rc1, which is not installed.\u001b[0m\n",
-      "\u001b[31mpy2neo 4.0.0 requires colorama, which is not installed.\u001b[0m\n",
-      "\u001b[31mpy2neo 4.0.0 requires neo4j-driver>=1.6.0, which is not installed.\u001b[0m\n",
-      "\u001b[31mkeras 2.2.0 has requirement keras_applications==1.0.2, but you'll have keras-applications 1.0.6 which is incompatible.\u001b[0m\n",
-      "\u001b[31mkeras 2.2.0 has requirement keras_preprocessing==1.0.1, but you'll have keras-preprocessing 1.0.5 which is incompatible.\u001b[0m\n",
-      "Installing collected packages: tables\n",
-      "\u001b[33m  The scripts pt2to3, ptdump, ptrepack and pttree are installed in '/eos/user/w/woodson/.local/bin' which is not on PATH.\n",
-      "  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.\u001b[0m\n",
-      "Successfully installed tables-3.5.1\n",
-      "\u001b[33mYou are using pip version 10.0.1, however version 19.1.1 is available.\n",
-      "You should consider upgrading via the 'pip install --upgrade pip' command.\u001b[0m\n"
-     ]
-    }
-   ],
-   "source": [
-    "# install tables (missing from SWAN stack)\n",
-    "!pip install tables --user\n",
-    "import sys\n",
-    "sys.path.append('$CERNBOX_HOME/.local/lib/python2.7/site-packages')\n",
-    "# restart notebook after this step (only needed once)!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Using TensorFlow backend.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import keras\n",
     "import numpy as np\n",
@@ -66,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,23 +111,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "190517 20:31:53 368 secgsi_InitProxy: cannot access private key file: /eos/user/w/woodson/.globus/userkey.pem\n",
-      "[1.403GB/1.403GB][100%][==================================================][102.6MB/s]  \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# copy training file if it doesn't exist\n",
     "import os.path\n",
     "if not os.path.isfile('ntuple_merged_10.h5'): \n",
-    "    !xrdcp root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/train/ntuple_merged_10.h5 .\n",
+    "    !xrdcp root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNtupleProducerTool/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/train/ntuple_merged_10.h5 .\n",
     "\n",
     "# load training file\n",
     "feature_array, label_array = get_features_labels('ntuple_merged_10.h5', remove_mass_pt_window=False)"
@@ -183,36 +126,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "_________________________________________________________________\n",
-      "Layer (type)                 Output Shape              Param #   \n",
-      "=================================================================\n",
-      "input (InputLayer)           (None, 27)                0         \n",
-      "_________________________________________________________________\n",
-      "bn_1 (BatchNormalization)    (None, 27)                108       \n",
-      "_________________________________________________________________\n",
-      "dense_1 (Dense)              (None, 64)                1792      \n",
-      "_________________________________________________________________\n",
-      "dense_2 (Dense)              (None, 32)                2080      \n",
-      "_________________________________________________________________\n",
-      "dense_3 (Dense)              (None, 32)                1056      \n",
-      "_________________________________________________________________\n",
-      "output (Dense)               (None, 2)                 66        \n",
-      "=================================================================\n",
-      "Total params: 5,102\n",
-      "Trainable params: 5,048\n",
-      "Non-trainable params: 54\n",
-      "_________________________________________________________________\n",
-      "None\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# define dense keras model\n",
     "inputs = Input(shape=(nfeatures,), name = 'input')  \n",
@@ -228,87 +144,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Train on 150255 samples, validate on 37564 samples\n",
-      "Epoch 1/100\n",
-      "150255/150255 [==============================] - 2s 15us/step - loss: 0.2939 - acc: 0.8945 - val_loss: 0.2455 - val_acc: 0.9052\n",
-      "Epoch 2/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2390 - acc: 0.9084 - val_loss: 0.2395 - val_acc: 0.9075\n",
-      "Epoch 3/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2339 - acc: 0.9102 - val_loss: 0.2364 - val_acc: 0.9087\n",
-      "Epoch 4/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2309 - acc: 0.9112 - val_loss: 0.2344 - val_acc: 0.9092\n",
-      "Epoch 5/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2289 - acc: 0.9118 - val_loss: 0.2329 - val_acc: 0.9092\n",
-      "Epoch 6/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2273 - acc: 0.9124 - val_loss: 0.2318 - val_acc: 0.9095\n",
-      "Epoch 7/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2260 - acc: 0.9132 - val_loss: 0.2309 - val_acc: 0.9099\n",
-      "Epoch 8/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2249 - acc: 0.9137 - val_loss: 0.2300 - val_acc: 0.9099\n",
-      "Epoch 9/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2239 - acc: 0.9141 - val_loss: 0.2293 - val_acc: 0.9103\n",
-      "Epoch 10/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2230 - acc: 0.9142 - val_loss: 0.2288 - val_acc: 0.9105\n",
-      "Epoch 11/100\n",
-      "150255/150255 [==============================] - 2s 11us/step - loss: 0.2222 - acc: 0.9145 - val_loss: 0.2282 - val_acc: 0.9110\n",
-      "Epoch 12/100\n",
-      "150255/150255 [==============================] - 2s 11us/step - loss: 0.2214 - acc: 0.9148 - val_loss: 0.2276 - val_acc: 0.9110\n",
-      "Epoch 13/100\n",
-      "150255/150255 [==============================] - 2s 13us/step - loss: 0.2207 - acc: 0.9154 - val_loss: 0.2274 - val_acc: 0.9112\n",
-      "Epoch 14/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2201 - acc: 0.9155 - val_loss: 0.2271 - val_acc: 0.9113\n",
-      "Epoch 15/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2195 - acc: 0.9157 - val_loss: 0.2268 - val_acc: 0.9115\n",
-      "Epoch 16/100\n",
-      "150255/150255 [==============================] - 2s 13us/step - loss: 0.2190 - acc: 0.9162 - val_loss: 0.2265 - val_acc: 0.9119\n",
-      "Epoch 17/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2185 - acc: 0.9163 - val_loss: 0.2264 - val_acc: 0.9121\n",
-      "Epoch 18/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2180 - acc: 0.9167 - val_loss: 0.2264 - val_acc: 0.9120\n",
-      "Epoch 19/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2175 - acc: 0.9168 - val_loss: 0.2263 - val_acc: 0.9120\n",
-      "Epoch 20/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2171 - acc: 0.9171 - val_loss: 0.2263 - val_acc: 0.9120\n",
-      "Epoch 21/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2167 - acc: 0.9173 - val_loss: 0.2264 - val_acc: 0.9119\n",
-      "Epoch 22/100\n",
-      "150255/150255 [==============================] - 2s 10us/step - loss: 0.2163 - acc: 0.9173 - val_loss: 0.2264 - val_acc: 0.9121\n",
-      "Epoch 23/100\n",
-      "150255/150255 [==============================] - 2s 11us/step - loss: 0.2159 - acc: 0.9174 - val_loss: 0.2264 - val_acc: 0.9120\n",
-      "Epoch 24/100\n",
-      "150255/150255 [==============================] - 2s 11us/step - loss: 0.2156 - acc: 0.9175 - val_loss: 0.2264 - val_acc: 0.9119\n",
-      "Epoch 25/100\n",
-      "150255/150255 [==============================] - 2s 11us/step - loss: 0.2153 - acc: 0.9175 - val_loss: 0.2263 - val_acc: 0.9120\n",
-      "Epoch 26/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2149 - acc: 0.9176 - val_loss: 0.2263 - val_acc: 0.9118\n",
-      "Epoch 27/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2147 - acc: 0.9178 - val_loss: 0.2265 - val_acc: 0.9118\n",
-      "Epoch 28/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2144 - acc: 0.9180 - val_loss: 0.2263 - val_acc: 0.9117\n",
-      "Epoch 29/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2141 - acc: 0.9181 - val_loss: 0.2263 - val_acc: 0.9117\n",
-      "Epoch 30/100\n",
-      "150255/150255 [==============================] - 2s 12us/step - loss: 0.2139 - acc: 0.9181 - val_loss: 0.2263 - val_acc: 0.9116\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<keras.callbacks.History at 0x7fa5e0ec5c50>"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# define callbacks\n",
     "early_stopping = EarlyStopping(monitor='val_loss', patience=10)\n",
@@ -323,23 +161,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "190517 20:33:37 489 secgsi_InitProxy: cannot access private key file: /eos/user/w/woodson/.globus/userkey.pem\n",
-      "[1.403GB/1.403GB][100%][==================================================][102.6MB/s]  \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# copy testing file if it doesn't exist\n",
     "import os.path\n",
     "if not os.path.isfile('ntuple_merged_0.h5'): \n",
-    "    !xrdcp root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/test/ntuple_merged_0.h5 .\n",
+    "    !xrdcp root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNtupleProducerTool/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/test/ntuple_merged_0.h5 .\n",
     "        \n",
     "# load testing file\n",
     "feature_array_test, label_array_test = get_features_labels('ntuple_merged_0.h5')"
@@ -347,20 +176,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAagAAAEYCAYAAAAJeGK1AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzt3Xd8VGX2x/HPSSihozSpAgIRBEFEFBSFVRRUdFfRBXXtsq661tWfru7q2nV17Q3rqit2UWyoSCyoNAWlh04o0iGhhSTn98cMMSFtIJncmcn3/XrxYu5zZ+6ceQhz8tz73POYuyMiIhJrkoIOQEREpDhKUCIiEpOUoEREJCYpQYmISExSghIRkZikBCUiIjFJCUpERGKSEpSIiMSkakEHUBYzqwM8CWQDae7+v4BDEhGRShDICMrMXjCz1WY2Y7f2QWY218zmm9mN4ebTgLfd/RLglEoPVkREAhHUKb6XgEEFG8wsGXgCGAx0AYabWRegFbAs/LTcSoxRREQCFMgpPnf/2sza7tbcG5jv7gsBzOx14FQgg1CSmkYpCdXMRgAjAFJSUg5t06ZNxQeeAPLy8khK0qXHkqh/Sqa+KZn6pnjLMvPIdcheNX+tuzfZ09fH0jWolvw2UoJQYjoceBR43MxOAsaU9GJ3HwmMBEhNTfW5c+dGMdT4lZaWRv/+/YMOI2apf0qmvimZ+qao9F8zGfjQ1wAsue/kJXtzjFhKUFZMm7v7FuCCyg5GRET23vvTVpT7GLE0Js0AWhfYbgWU/xOKiEile3z8fACa1a+518eIpQQ1GehoZu3MrAYwDPhgTw5gZkPMbGRWVlZUAhQRkbKt3rw9//HALs32+jiBnOIzs1FAf6CxmWUAt7r782Z2BTAWSAZecPeZe3Jcdx8DjElNTb1k9307d+4kIyOD7du3F/PKqqNBgwbMnj076DDypaSk0KpVK6pXrx50KCJSQV78bnH+4y7NG+z1cYKaxTe8hPaPgY+j8Z4ZGRnUq1ePtm3bYlbc5a6qITMzk3r16gUdBgDuzrp168jIyKBdu3ZBhyMiFWD7zlzemhKa79a5eX2GHdaas/fyWLF0ii+qtm/fTqNGjap0coo1ZkajRo2q/KhWJJFc99Z01mZlA3DOEW1IStr779yESlBlXYNScoo9+jcRSRyfzVzFRz+vBKDVPrUYemirch0voRKUu49x9xF169YNOhQRkSolL88Z8cpUAJKTjPuHHkzNasnlOmZCJah48N5772FmzJkzJ78tLS2Nk08+udDzzj//fN5++20gNMHjxhtvpGPHjvTs2ZM+ffrwySeflCuO7OxsLrjgArp160b37t1JS0vL3zd16lS6detGhw4duPLKK3H3Yo+RlpZGjx49OOiggzjmmGMAWLNmDUcddRRdu3Zl9OjR+c899dRTWbFCdw2IJKoXJizKf/yHQ1rS94DG5T6mElQlGzVqFEcddRSvv/56xK/5xz/+wcqVK5kxYwY//vgjo0ePJjMzs1xxPPvsswD88ssvfP7551x33XXk5eUB8Je//IWRI0eSnp5Oeno6n376aZHXb9y4kcsuu4wPPviAmTNn8tZbb+V/vksvvZRJkybx8MMPAzBmzBh69uxJixYtyhWziMSmmSs2cedHodnBrfapxW2nHFQhx02oBBXr90FlZWUxYcIEnn/++YgT1NatW3n22Wd57LHHqFkzdMNbs2bNOPPMM8sVy6xZszj22GMBaNq0KQ0bNmTKlCmsXLmSzZs306dPH8yMc889t9BIaJfXXnuN0047jV01D5s2bQpA9erV2bp1Kzt27CA5OZmcnBwefvhhrr/++nLFKyKxKSc3j/975+f87X+e3IW6NStmgngslToqt9LugyroX2NmMmvF5gp//y4t6nPrkJJ/cxg9ejSDBg2iU6dO7Lvvvvz444/07Nmz1GPOnz+fNm3aUL9+/TLf/5prrmH8+PFF2ocNG8aNN95YqK179+68//77DBs2jGXLljF16lSWLVtGUlISrVr9dmGzVatWLF++vMgx582bx86dO+nfvz+ZmZlcddVVnHvuuZx11lmcddZZjBw5kvvuu48nn3ySc889l9q1a5cZv4jEn1GTljJjeej79Lw++3P8QftV2LETKkFFataKzUxctL7S33fUqFFcffXVQChpjBo1ip49e5Y4k21PZ7g99NBDET/3wgsvZPbs2fTq1Yv999+fvn37Uq1atWKvNxUXR05ODlOnTmXcuHFs27aNPn36cMQRR9CpUyc++ugjADZs2MB9993Hu+++yyWXXMKGDRu47rrr6NOnzx59LhGJTXNWbc4/tbdP7er83+ADK/T4VTJBdWlR9mikoo+7bt06vvzyS2bMmIGZkZubi5lx//3306hRIzZs2FDo+evXr6dx48Z06NCBpUuXRnSD7Z6MoKpVq1YoofXt25eOHTuyzz77kJGRkd+ekZFR7LWjVq1a0bhxY+rUqUOdOnU4+uijmT59Op06dcp/zu23387NN9+cf91t6NChnHbaaYwdO7bUzyEisS8vz7nxnV/YkRO6dn3v6QdTu0bFppQqmaBKOw0XLW+//TbnnnsuzzzzTH7bMcccw7fffkvv3r1ZsWIFs2fPpnPnzixZsoTp06fTo0cPateuzUUXXcSVV17JM888Q40aNVizZg1paWmcccYZhd5jT0ZQW7duxd2pU6cOn3/+OdWqVaNLly4A1KtXjx9++IHDDz+cl19+mb/+9a9FXn/qqadyxRVXkJOTQ3Z2NhMnTuSaa67J35+ens6KFSs45phjmDZtGikpKZgZ27Zt29OuE5EY9NAX85i2bCMAZx/ehhMq8NTeLgmVoMxsCDAkFmeLjRo1qsgo5vTTT+e1116jX79+vPrqq1xwwQVs376d6tWr89xzz9GgQaiG1Z133sktt9xCly5dSElJoU6dOtx+++3limf16tWccMIJJCUl0bJlS1555ZX8fU899RTnn38+27ZtY/DgwQwePBiAp59+GoBLL72Uzp07M2jQIA4++GCSkpK4+OKL6dq1a/4xbr75Zu666y4Ahg8fzu9//3vuvffecsctIsF77puFPPZlqFp547o1K/zU3i5W0j0u8ay4BQt3jU6quliqxbdLLP3baOG5kqlvSlaV+mbszFX8OXxDboNa1Rl1yRFlXjYxs6nu3mtP3yuhppmLiEj0zPs1k2vemAZAtSTjufN6Re2aPihBiYhIBBauyeLs5yayNTsXgAfP7M5hbfeN6nsm1DWosri7ipPGmEQ8xSySaOb9msnpT35H5o4cAK48tiOn9mgZ9fetMiOolJQU1q1bpy/EGLJrPaiUlJSgQxGREmzLzuWSl6fkJ6dL+rXj2oGdynhVxUioEVRps/hatWpFRkYGa9asqfzAYsj27dtjKiHsWlFXRGKPu/PP92ewZN1WIDSd/OaTulTa+ydUgiqt1FH16tW1aiuh2UaHHHJI0GGISBx4bdJS3poaunG/W8sGFVYENlJV5hSfiIhEbt6vmdz5YaiMUb2a1XjirJ5UT67clKEEJSIihfy6eTvnvzCJbTtDM/buPq0bbRpVfsFnJSgREcm3YuM2Tn/qO1Zs2g7A6T1bMaR7MNV5EuoalIiI7L2Fa7I485nvWZuVDcCgg/bjvtO7BRaPEpSIiPBN+hquen0a67eEktNpPVvy76HdSU4K7t5RJSgRkSpu9E/LufbNaeSFbxM9t8/+/OuUgwIvbJBQCSqWq5mLiMSit6dm8Le3pgOQnGTcOqQL5/ZpG2xQYQk1ScLdx7j7iLp16wYdiohIzHt/2nJufOfn/O0nzuoZM8kJEmwEJSIikSk4cjKDZ845lOOjsOhgeShBiYhUMW9OWcYNb4dGTkkGz59/GANSmwYcVVFKUCIiVchj49J58PN5QGhNpyfP7hmTyQmUoEREqoTcPOf+T+fwzNcLAahTI5ln/tSLozo2DjiykilBiYgkuO07c/nzK1P5al5oNYfaNZJ5fUQfurVqEHBkpVOCEhFJYGuzdvDnV6YydckGAJrWq8lLF/SO6lLtFUUJSkQkQS3fuI1hI79n2fptABzSpiEvXdCbBrWqBxxZZBIqQelGXRGRkPmrMzn7uYn8unkHAMce2JTHzjqE2jXi52tfN+qKiCSY6cs2ctqT3+UnpyHdW/Dceb3iKjlBgo2gRESqstw859UflnDXR7PJzs0D4MIj2/GPkzsHXldvbyhBiYgkgIVrsrjuren8tHRjftsNg1K5rH+HAKMqHyUoEZE4N2nRes585vv87Wb1a3Ln77sxsEuzAKMqPyUoEZE45e488/VCHhg7N7/t/L5tuWFQatxdbypO/H8CEZEqaNHaLVz35jR+LHBK789Ht+emEzsHGFXFUoISEYkzr09ayh0fzmJLdi4AzRuk8J8ze9DngEYBR1axlKBEROLE8o3buPX9mXwx+9f8tqGHtuKWkzrTsHaNACOLDiUoEZE48N5PGfxz9Ewyd+QAUD+lGg+e2SPuJ0KURglKRCSGZW7fyXVvTuezWb+Nmk44qBm3DjmIFg1rBRhZ9ClBiYjEqLEzV3HHh7PI2BCqpZdSPYnbT+3Kmb1aBxxZ5VCCEhGJMbNWbOaeT2bzTfra/LZ+HRvznzN70KRezQAjq1xKUCIiMWJ15nbu/XgO701bjnuorWa1JK4/IZULj2xHUlL8lSsqj4RKUKpmLiLx6selG7jopcls2LoTADP4Y6/WXD6gA633rR1wdMFIqATl7mOAMampqZcEHYuISCS27Mjhgc/m8uKExfltvdvty+2nHsSB+8X+ooLRlFAJSkQknsxeuZkLX5rMyk3bAUhOMm44IZURR7ePy+rjFU0JSkSkkm3cms1jX87nv98tJicvdLHpwP3q8cAZ3enaskHA0cUOJSgRkUqSk5vHez8t595P5rBuSzYQutZ0Xp+23HxSZ6onJ9QasuWmBCUiUgnSf83kxnd/YeqSDflt7RrX4b7TD6Z3u30DjCx2KUGJiETRsvVbufeTOXz0y8r8tnop1fj7iZ0ZdlhrXWsqhRKUiEgU5OY5L323mDs+nFWo/fSerfjnkC40qFU9oMjihxKUiEgFys7J4+XvF/P0VwtYm5Wd396vY2OuOz6VHq0bBhdcnFGCEhGpIN+kr+Gmd3/Jr50HobWarh3YiTOqSP28iqQEJSJSTnnu3Pr+DP77/ZL8tuYNUri4X3uG926dEMuvB0G9JiJSDt8tWMs/J2wjIyuUnJIMrh3YiYv7tSelenLA0cU3JSgRkb2Q/msmd3w0m6/nrclva1a/Jv+9sHeVL1FUUZSgRET2wMwVm3hxwmLe/TGDcBEIDLjk6PZcdWxH6tTU12pFUU+KiJTB3fl2/loeHZfO5MW/3WhrBqd0b0Hvuhs4+8TOAUaYmJSgRERKsGFLNq9NWsr/fljCinBB112O7tSEG05IpWvLBqSlpQUTYIJTghIR2c2WHTk8mTafF75dzLadufnt1ZON4b3bMOLo9rTap2qu0VSZIkpQZlYLaOPuc6Mcj4hIoCYtWs8Vr/3I6swd+W0dmtblnMPbcGK35jStnxJgdFVLmQkqvErtA0ANoJ2Z9QBud/dToh2ciEhlmfdrJvd+Mocv56zOb+vcvD7XHNeRgV2aqWZeACIZQd0G9AbSANx9mpm1jVpEuzGz9sDNQAN3H1pZ7ysiVUPGhq08MX4+oyYtK9R+Sb923DS4M0lJSkxBiSRB5bj7pr357cHMXgBOBla7e9cC7YOAR4Bk4Dl3v7ekY7j7QuAiM3t7jwMQESlBxoatPDounXd/XJ6/aCDASd2ac+3xnTigSd0AoxOILEHNMLOzgGQz6whcCXwX4fFfAh4HXt7VYGbJwBPAQCADmGxmHxBKVvfs9voL3X01IiIVZGt2Dk+Mn8/IrxeyM/e3xNT3gEbcMOhAFXONIZEkqL8SOsW2A3gNGAvcEcnB3f3rYk4H9gbmh0dGmNnrwKnufg+h0ZaISIXbmZvHqElLeXL8AlZt/m3KeJ/2jfjbCakcuv8+AUYnxTF3L/0JZme4+1tltZXy+rbAh7tO8ZnZUGCQu18c3v4TcLi7X1HC6xsBdxEacT0XTmTFPW8EMAKgSZMmh7755puRhFflZGVlUbeuTl2URP1Tsnjum2mrc3h1djZrt/32fdestnFO5xp0a1L+u23iuW8qw4ABA6a6e689fV0k/zI3Absno+LaIlXcxawSs6S7rwMuLeug7j4SGAmQmprq/fv338vwEltaWhrqm5Kpf0oWj32zeO0WHvpiHu9PW5HfVj+lGlcd14nz+7YluYImQMRj38SDEhOUmQ0GTgRamtmjBXbVB3LK8Z4ZQMGFUVoBK0p4rojIHnF3Ppv1Ky9NWMz3C9flt9eqnszVx3XkvL5tVWU8TpQ2gloBTAFOAaYWaM8ErinHe04GOppZO2A5MAw4qxzHyxe+Z2tIixYtKuJwIhJH3J1xs1dz98ezWbh2S6F9/VOb8I+Tu2hmXpwpMUG5+3Rgupm95u479+bgZjYK6A80NrMM4FZ3f97MriA02SIZeMHdZ+7N8YuJeQwwJjU19ZKKOJ6IxIefMzZy36dzmDD/txFTnRrJDD20FUMPbU23Vg0CjE72ViTXoNqa2T1AFyC/xoe7ty/rhe4+vIT2j4GPIw1SRKQ4azJ38J/P5xa6yTY5yTi/b1uu/F1HGtSuHmB0Ul6RJKgXgVuBh4ABwAVAUjSDEhEpzcat2Tz/7SKe+Woh2bl5QGgl28Fdm3PrkC6ql5cgIklQtdx9nJmZuy8BbjOzqcA/oxzbHtM1KJHEti5rB6OnreCxL9PZuPW3Kw/dWzXg3tMPpnNzrWSbSCJJUNvNLAlID187Wg7E5JVGXYMSSUwzlm/iqbQFfDpzFbkFyhK1b1KH649PZXC35gFGJ9ESSYK6GqhNqMTRHYRO850XzaBERAAWrd3CI1/MY/S0wneiNG+QwmX9D+CcI/ZXlfEEVmqCCtfN+6O7/w3IInT9SUQkqqYv28hdH81m8pL1FCx2c/LBzRl6aCv6dWxSYTfZSuwqNUG5e66ZHVVZwYhI1bZk3RZufm8G385fW6j9mE5NuOWkznRsVi+gyCQIkZzi+ylcbfwtIP/uN3d/N2pR7SVNkhCJT7NXbubprxYUKkkEcMJBzRh6aGsGdmkWUGQSpEgSVAqwDvhdgTYHYi5BaZKESHxZtHYLD4ydy0e/rCzUfljbfbjv9INpr8oPVVqZCcrddd1JRCrU7JWbGfn1QkZPW17oGlPfAxox9NBW/OGQlpr8IBGNoEREKsQPC9fxVNoCvpq3plD7YW334ZaTutBdiwVKAUpQIhJ1X875lcv/9xPbduYWau/XsTGX9e9AnwMaBRSZxLKESlCaJCESO3Jy83jvp+Xc+O4vhW6uBTi1Rwsu69+B1P00K09KVmaCMrNmwN1AC3cfbGZdgD7u/nzUo9tDmiQhErztO3N55fslPPplOpnbCy8d171VAx48swcdmmryg5QtkhHUS4QKxt4c3p4HvAHEXIISkeC4O5/MWMX1b01nS3bhU3mnHdKSvx7bkXaN6wQUncSjSBJUY3d/08xuAnD3HDPLLetFIlI1bMvO5d9j5/LZrFVkbNhWaN/FR7XjmoGdqFMzoa4mSCWJ5Kdmi5k1InTvE2Z2BLApqlGJSMzLy3Pe/Wk5d388m/VbsvPb69asxoVHteOy/gdoaXUpl0gS1HXAB8ABZjYBaAIMjWpUIhKzNm3byZuTl/HIuHSydvx2jWmf2tXp26FxaD2melqPScovkht1p5rZMUAqYMDcvV0CPto0i08kerKynUe+SOeRcfPYbVIelw84gKuP60T1ZK1lKhUnkll80wlNinjD3RdEP6S9p1l8IhVr18SH/01cwoT5WwnNkQpJqZ7Emb1a8+djDqBlw1rBBSkJK5JTfKcAfwTeNLM8QsnqTXdfGtXIRCQw67J28P60FYyatJT01VlF9j9wRneGdG9OzWq6xiTRE8kpviXA/cD9ZtYR+AdwH6CfTJEEM391Jk+lLeSdHzOK7KtTHe4+vQcndWtONZ3Kk0oQ0dxPM2sLnEloJJUL3BC9kESksn09bw23jZnJwjVbCrUnJxkjjm7PBX3bMuvHH+jfo2VAEUpVFMk1qIlAdULrQZ3h7gujHpWIRF3Wjhw+/mUl/5u4lOnLNhbZ/5f+B3D98akkhVeunVXZAUqVF8kI6jx3nxP1SESkUsxcsYn3p63ghW8XkbPbdLw+7RsxrHdrhhzcIj8xiQSlxARlZue4+6vAiWZ24u773f0/UY1sL2iauUjxdtXH+3TmKqYu2VBoX7UkY2CXZpzbp62qiktMKW0EtatoVnHlhr2YtsBpmrlIYRu3ZvOfz+fx2sSlRUZLADcNPpALj2qn+5ckJpWYoNz9mfDDL9x9QsF9ZnZkVKMSkXLZlp3Lo1+m81Ra0VsXz+/blhO7Nad3u30DiEwkcpFcg3oM6BlBm4gEyN35dMYqHhmXzpxVmYX2Na5bk7MOb8Olx7Sndg0VbpX4UNo1qD5AX6CJmV1bYFd9dA+USMxwd8b8vJI7P5zF6swdRfaPOLo9Nw0+EDNNepD4UtqvUjWAuuHnFLwOtRkVixUJXNaOHEZ+tYC3p2awYtP2IvuvHdiJS/q1p1YN/T4p8am0a1BfAV+Z2UvhahIiErBt2bm8PXUZI79ZyIqN2wstpV6jWhKndm/Blcd2pPW+tQOMUqRilHaK72F3vxp43MyKTP9x91OiGpmIALB+SzY3vfszExetZ+PWogsJJCcZQw5uzk0ndqZZfS1zIYmjtFN8r4T/fqAyAhGRwhav3cL/Ji7h2W8WFbu/UZ0aXHVcR4Yd1oYa1TRNXBJPaaf4pob//mpXm5ntA7R2958rITaRKic3z3lxwiJenLCY5Ru3Fdl/RPt9Oalbc04+uAX71KkRQIQilSeSWnxphJbcqAZMBVab2QR3v7bUFwZAlSQkXu3MzeOxL+fzwbTlLF63tdC+9o3rcPmADpzao4WqiEuVEskNEQ3cfbOZXQy87O63mllMjqBUSULizYI1WTz42Vw+/mVVkX3Vk43Hz+rJ8V2aaYq4VEmRJKhqZtac0HIbN0c5HpEqYW3WDq547Ud+WLi+yL5zjmjDFQM6sl8DTXiQqi2SBHU7MBaY4O6Tzaw9kB7dsEQS04Yt2fz7s7m8NrHwgtRdmtfn5O7NueiodlqlViQskhV13yK0FtSu7YXA6dEMSiQRpf+aycCHvi7Utl/9FG4+qTNDuuu6qcjuIpkk0YpQ7b0jCVUx/xa4yt2LrgktIkXk5Obx3LeLuPeTwsuqPTb8ECUmkVJEcorvReA14Izw9jnhtoHRCkokEWRu38nVr09j3JzVhdoPalGfN/7ch7o1VbRVpDSR/A9p4u4vFth+ycyujlZAIvFua3YOd388m1d/WFpk30ndmvPE2VoIQCQSkSSotWZ2DjAqvD0cWBe9kETi04c/r+CRL9JJX51VZN+gg/bjrj90pVHdmgFEJhKfIklQFwKPAw+FtyeE20QEmPdrJhf9dzLL1het/HD9Camc37ctdXQ6T2SPRTKLbymhShIiEubufDlnNU9/tYDJizcU2tejdUOOP6gZI/q1V+UHkXKIZBZfe+AR4AhCs/i+B64JTzcXqVJ25OTyyS+ruPqNaUX2VUsyPr26Hx2a1ivmlSKypyI57/Aa8ATwh/D2MELXow6PVlAisSQnN49HxqXz2Jfzi93fqE4N7vx9VwZ3a17JkYkktkgSVG13f6XA9qtmdn20AioPFYuVirQjJ5eHv0jnqbQFxe7v074R1w9KpWebfSo5MpGqIZIE9YmZ3Qi8TugU3x+Bj81sXwB3L1pMLCAqFisVIWtHDv8YPYP3flpe7P4ze7Xi2oGpqpUnEmWRJKgzw3//ebf2YYQSVvsKjUgkIHl5zkNTtzP907FF9nVtWZ9n/tSLlg1rBRCZSNUUySy+dpURiEhQvl+wjifT5vNN+toi+wakNuGBM7rr/iWRAOjmDKmS3J1nv1nI3R/PKXb/8N6t+dcpXbWUukiAlKCkSnF37vlkDm9NWcaGrTsL7UupnsQhTYz7zzma1vvWDihCEdlFCUqqhJWbtvHvT+fybjETH+qnVOPJsw/lqI6NSUtLU3ISiRGR3KhrwNlAe3e/3czaAPu5+6SoRydSAS55eQqfz/q1SHvvdvvy9DmHsm+dGgFEJSJliWQE9SSQB/yO0Oq6mcA7wGFRjEukXNydBz+bx4sTFrElO7fQvqb1avLOX/pqpCQS4yJJUIe7e08z+wnA3TeYmX7llJjk7pz06LfMWrm5yL5+HRvz7Lm9SKmuJdVF4kEkCWqnmSUTuucJM2tCaEQlElPGzlzFn1+ZWqS9S/P6PH3OobRppBGTSDyJJEE9CrwHNDWzu4ChwC1RjUokQjtz8xj61HdMz9hUZF/zBim8d9mRqvggEqciuVH3f2Y2FTgWMOD37j476pGJlGL9lmwufWUqkxYXX2nrmxsG6BqTSJyLZBbfAcAid3/CzPoDA81spbtvjHp0IrtZtHYLV78xjenLiv/xe+Ksnpx0sKqKiySCSE7xvQP0MrMOwDPAB4SW4DgxmoGJFOTuvD55GTe9+0ux+yf+/Via1depPJFEEkmCynP3HDM7DXjc3R/bNaNPJNq27Mjh7OcmMq2YEdMZh7bin0O6UC+legCRiUi0RTqLbzhwLjAk3KZvBImqzdt3cvhd49i2M7fIvsZ1azLx78eSnGQBRCYilSWSBHUBcClwl7svMrN2wKvRDUuqstcmLuXv7xV/Ku/dy/pqgUCRKiKSWXyzgCsLbC8C7o1mUFI1ZWzYyoAH0tiZ64Xaf3dgUx76Yw8a1NLAXaQqKTFBmdkvhG/OLY67HxyViKRKemxcOg9+Pq9I+5w7Bqnyg0gVVdoI6uRKi6IUZvZ74CSgPvC8u38WcEhSQXLznEfHpfPIuPQi+548uycndtN0cZGqrMQE5e5LyntwM3uBUKJb7e5dC7QPAh4BkoHn3L3EU4buPhoYbWb7AA8ASlAJ4LlvFnLnR8Xf761Rk4hAZDfqHgE8BnQGahBKKlvcvX4Ex38JeBx4ucDxkoEngIHwr+haAAARdUlEQVRABjDZzD4IH/ee3V5/obuvDj++Jfw6iWO5ec7Bt40tUmG8cd2aXHpMey7u1z6gyEQk1ph7iZeZQk8wmwIMA94CehGabt7J3W+K6A3M2gIf7hpBmVkf4DZ3PyG8fROAu++enHa93ghNyvjc3b8o5X1GACMAmjRpcuibb74ZSXhVTlZWFnXr1g3kvT9cmM3b83YWab/jyFq0rhcbS6sH2T+xTn1TMvVN6QYMGDDV3Xvt6esiWlHX3eebWbK75wIvhm/UjShBFaMlsKzAdgZweCnP/ytwHNDAzDq4+9MlxDgSGAmQmprq/fv338vwEltaWhqV3TcbtmQz/NkfmLOqcHK6/oRULh/QoVJjKUsQ/RMv1DclU99ERyQJamt4/adpZnY/sBIoz6+7xd1dWdpswUcJVVSXOLM2awcXvjSZn4upNP7FtcfQoal+4xSRkkWSoP5EKCFdAVwDtAZOL8d7ZoSPsUsrYEU5jicx6F9jZvLihMVF2i88sh3/HNKl8gMSkbhT2n1Qbdx9aYHZfNuBf1XAe04GOoYrUiwndH3rrAo4LmY2BBjSokWLijic7IUfl27gtCe/K9LepXl93r2sr2bniUjEShtBjQZ6ApjZO+6+x6MmMxsF9Acam1kGcKu7P29mVwBjCc3ce8HdZ+5x5MVw9zHAmNTU1Esq4ngSme07c7ntg5m8PnlZkX31alZj8i3HKTGJyB4rLUEVvFa0V3N/3X14Ce0fAx/vzTEldmzcmk2/+8eTuT2n2P2n9WzJf87sUclRiUiiKC1BeQmPpYpzdx76Ip1Hi6kAAfD0OYcyqOt+lRyViCSa0hJUdzPbTGgkVSv8mPC2R3ijbqXSNajoW7Z+K/3uH1+kvW7Nanz7fwNoWLtGAFGJSCIqrdRR3F000DWo6Gp740fFtk+/9XhVGheRChfRjbpSdeXmOZe8PIUv56wusu/Viw7nqI6NA4hKRKoCJSgp0civF3D3x3OKtB/ZoRH/vaA31ZJjozyRiCSmhEpQugZVMTZuzabH7Z8XaU8y+Piqfhy4X8xdfhSRBJRQCUrXoMpv7qpMTnj46yLt7/ylL4fur6XWRaTyJFSCkr2Xl+e0/3vRW9MO3K8en1zVj1BReRGRyqMEJSUmp+9v+h3NG9QKICIRESWoKi03z3nsy3Qe/qLoDbeaOi4iQUuoBKVJEpFzdw4oZtR072ndGNa7TQARiYgUllAJSpMkyrYzz0u84fb3PVooOYlIzEioBCWl+2LWr1zy2dYi7Xf+vivnHLF/ABGJiJRMCaqK2Jady8UvTynS/tk1R9OpWb0AIhIRKZ0SVBXx+PjCEyEm/v1YmtVPCSgaEZGyKUFVAYvXbuGJ8Qvytyf9/ViaKjmJSIxLqGJqZjbEzEZmZWUFHUrM2L4zl/4PpBVqU3ISkXiQUCMozeL7Teb2nXS77bMi7SMH1g4gGhGRPZdQIygJeX/a8mKT0/DebaiRrJJFIhIfEmoEJfDE+Pn8e+zcQm0H7lePFy84jOYNapGWlhZMYCIie0gJKkG4O+1uKloZ4rsbf0eLhqqnJyLxRwkqAWzYks0hdxRdv2nxvScFEI2ISMXQNagEUFxySr9rcACRiIhUHCWoOPbd/LVF6uqd0r0Fi+89iepajl1E4lxCfYtVpfuglq3fylnPTSzUdtbhbXh0+CEBRSQiUrESKkG5+xh3H1G3bt2gQ4mqUx//ln73jy/UVqdGMnf/oVtAEYmIVDxNkogjS9dt5eh/jy/Snn7XYJ3SE5GEo2+1OPHDwnXFJqcf/zFQyUlEEpJGUDFs+rKNjJm+gue+XVRk3+UDDuD6Ew4MICoRkcqhBBWDsnPyuPjlKXw9b02x+3++7Xjqp1Sv5KhERCqXElSMKWk5doCBXZox8k+HYqZ6eiKS+JSgYsi1b0wrtn3RPScqKYlIlaMEFSPy8px3f1peqO3583pxbOdmAUUkIhKshEpQZjYEGNKiRYugQ9kjr3y/mH+8P7NQm+roiUhVl1Dzk+PxRt1l67cWSU6jLz8yoGhERGJHQiWoeLR7RYg3RhxBj9YNA4pGRCR2JNQpvngzadH6Qtvz7xpMNd10KyICaAQVmDWZOzjzme/ztw9u1UDJSUSkAH0jBuSwu74otD3yT70CikREJDbpFF8Abvug8KSI2bcPolaN5ICiERGJTUpQlWjDlmye+moBL323OL/tyt91UHISESmGElQlmfdrJsc/9HWR9muPTw0gGhGR2KcEFWVrMndw8X8nMz1jU6H2RnVqMOWW4wKKSkQk9ilBRdH4uau54MXJRdrfu6wvB7dqqPp6IiKlUIKKkrVZO4okpwa1qvPZNUfTrH5KQFGJiMQPJagoWLVpO0fcM65Q25RbjqNx3ZoBRSQiEn90H1QU9Lm3cHL67sbfKTmJiOyhhEpQZjbEzEZmZWUF8v7uzl9H/YT7b22Tbz6OFg1rBRKPiEg8S6gEFXQ185+WbWTM9BX528ce2JQm9TRyEhHZGwmVoIL2/YJ1+Y+7t27IY2cdEmA0IiLxTZMkKsD2nbm8NTWDf4+dm9/2+PBDqF1D3Ssisrf0DVoBzn9xEj8sLLx0Rut9awcUjYhIYtApvnJasCarSHL65bbjA4pGRCRxaARVDv8eO4cnxi/I3+7WsgEfXHGkKkSIiFQAjaD20pYdOYWSE8Cbf+6j5CQiUkGUoPbSW1OWFdpO+1t/LZshIlKBlKD20m1jZuU/fveyvrRtXCfAaEREEo8S1F7Iy/NC24e0bhhQJCIiiUsJai+c+Og3vz3utp+uO4mIRIES1B56+It5zFmVmb99wwkHBhiNiEji0jTzCLk7l7/2Ix//siq/rVn9mrr2JCISJRpBRWjy4g2FkhPAV9cPCCgaEZHEpwQVoUtenpL/uEvz+sy6/QRSqmtauYhItChBRSBt7mo2bduZv/3iBYepEKyISJQpQZVh07adnP/i5Pztkw9uTrP6KQFGJCJSNShBlcLd6f6vzwq1PX5Wz4CiERGpWpSgSrE2K7vQ9vuXHxlQJCIiVU/MJygz62xmT5vZ22b2l8p872vfnJb/+MpjO9JdFSNERCpNVBOUmb1gZqvNbMZu7YPMbK6ZzTezG0s7hrvPdvdLgTOBShvCrNq0nW/S1+Zvn9dn/8p6axERIfojqJeAQQUbzCwZeAIYDHQBhptZFzPrZmYf7vanafg1pwAfAR9HOV4gVGvviHvGFWprVLdmZby1iIiEmbuX/azyvIFZW+BDd+8a3u4D3ObuJ4S3bwJw93siONZH7n5SCftGACPCm12BGcU9T2gMrC3zWVWX+qdk6puSqW9Kl+ru9fb0RUHczNMSKLiYUgZweElPNrP+wGlATUoZQbn7SGBk+DVT3L1XRQSbaNQ3pVP/lEx9UzL1TenMbErZzyoqiARVXOnvEodx7p4GpEUrGBERiU1BzOLLAFoX2G4FrAggDhERiWFBJKjJQEcza2dmNYBhwAcV/B4jK/h4iUR9Uzr1T8nUNyVT35Rur/onqpMkzGwU0J/QBcRfgVvd/XkzOxF4GEgGXnD3u6IWhIiIxKWoz+ITERHZGzFfSUJERKqmuE5QZVWkMLOaZvZGeP/E8D1ZVUIEfXOtmc0ys5/NbJyZVZlSGZFWMjGzoWbmZlalpg9H0j9mdmb452emmb1W2TEGJYL/V23MbLyZ/RT+v3ViEHEGoaTKQQX2m5k9Gu67n82s7Mrb7h6Xfwhdv1oAtAdqANOBLrs95zLg6fDjYcAbQccdQ30zAKgdfvwX9U2R59UDvgZ+AHoFHXcs9Q/QEfgJ2Ce83TTouGOob0YCfwk/7gIsDjruSuyfo4GewIwS9p8IfELoVqMjgIllHTOeR1C9gfnuvtDds4HXgVN3e86pwH/Dj98GjjWz4u7DSjRl9o27j3f3reHNHwhN968KIvm5AbgDuB/YXpnBxYBI+ucS4Al33wDg7qsrOcagRNI3DtQPP25AFbqFxt2/BtaX8pRTgZc95AegoZk1L+2Y8ZygiqtI0bKk57h7DrAJaFQp0QUrkr4p6CJCv9lUBWX2jZkdArR29w8rM7AYEcnPTiegk5lNMLMfzGwQVUMkfXMbcI6ZZRCqfPPXygktLuzp91IglSQqSiQVKfaoakUCifhzm9k5QC/gmKhGFDtK7RszSwIeAs6vrIBiTCQ/O9UInebrT2jk/Y2ZdXX3jVGOLWiR9M1w4CV3fzBcd/SVcN/kRT+8mLfH38fxPIKKpCJF/nPMrBqhIXdpQ9BEEVG1DjM7DrgZOMXdd1RSbEErq2/qESo2nGZmiwmdK/+gCk2UiPT/1fvuvtPdFwFzCSWsRBdJ31wEvAng7t8DKYTuA5W9qCIUzwkqkooUHwDnhR8PBb708NW6BFdm34RPYz1DKDlVlWsIUEbfuPsmd2/s7m3dvS2h63OnuPteFbuMQ5H8vxpNaJINZtaY0Cm/hZUaZTAi6ZulwLEQWmyVUIJaU6lRxq4PgHPDs/mOADa5+8rSXhC3p/jcPcfMrgDG8ltFiplmdjswxd0/AJ4nNMSeT2jkNCy4iCtPhH3zb6Au8FZ43shSdz8lsKArSYR9U2VF2D9jgePNbBaQC1zv7uuCi7pyRNg31wHPmtk1hE5fnV9FfikuVDkofA3uVqA6gLs/Teia3InAfGArcEGZx6wifSciInEmnk/xiYhIAlOCEhGRmKQEJSIiMUkJSkREYpISlIiIxCQlKKkyzKyRmU0L/1llZssLbNcIOr7dmdmLZpZqZkkFK2ebWbKZfVPJsVxrZimV+Z4immYuVZKZ3QZkufsDu7Ubof8XMVOaJlwFZa27N4zie5T6ucP3tVSFckYSQzSCkirPzDqE1zb6HzATaG1mGwvsH2Zmz4UfNzOzd81siplNCt8Rv/vxLjaz98zsKzNLN7NbCuy7wcxmhP/8NdxWz8w+MbPp4fah4fZvzawHcC9QLzzSe9nMqu2Kz8zeMbPjCxz/VTM7Nfyc/4Rj/NnMLo7gczc3s5HhzzbTzP4Zft41QFNCNfe+CLcNNrPvzexHC625Vqe8/w4iu4vbShIiFexA4Dx3nxwesZTkUeB+d//BQgtgfkiodt/ueofbs4HJZvYhoTWEzg7vSwYmmdlXQGdC6wYNBjCzBrsd60bgYnfvEd5fML7XgT8Cn4VPwR1DqB7cCGC1u/c2s5rAD2b2mbsvLelzh499o7uvD7/HeDN7290fMrPrgH7uvtHMmoZjOtbdt5rZzcBVwN2l9JvIHlOCEglZsOtLugzHAan227Ji+5hZLXffttvzxu5aL8nMRgNHATWBd3atw1WgfTxwr5ndC4xx9wl7EPdHwINmVh04iVC9yR3hUVVnM9tV3qsBoYKuuyeo3T/3cDO7iNB3QwtCi+7N2u01fcPt34X7oQbw7R7ELBIRJSiRkC0FHudReGmAgpMDDOgdXrCuNLtf3PXdjvnbDvfZFqqWfiKhRPWJu0c0GgmPYCYAAwmNpF4sEOdl7j6ujEPkf24z60hoJNQ7PFJ6lcKfPf+pwKfu/qdIYhTZW7oGJbKb8ESBDWbW0ULrQ/2hwO4vgMt3bYSvERXneDNraGa1Ca0kOoHQEvJ/MLNaZlY33P6NmbUkNGHjFeBBQstmF4wnJ/xeJf1C+Tqh03p9wvFBqKDpZbteE54NWKuMj14fyAQ2W2il0xMK7MsktBQJwHfAMWbWPnzsOuHkJlKhNIISKd7/EfqSXw1MJXR6DkLJ6Skzu4DQ/5/xFEhYBUwG3id0muy/7j4N8is+7zql9pS7/2Jmu0ZOeYSuWV1azPGeB342synAhbvt+xT4L/CWu+8Mtz0DtAGmhU/Drab4pe0L+pHQ6bw5wBJCSXWXkcAXZrbM3Y8LnwZ8o8D0/L8D6WUcX2SPaJq5SAULz5jr6u5XBx2LSDzTKT4REYlJGkGJiEhM0ghKRERikhKUiIjEJCUoERGJSUpQIiISk5SgREQkJv0/YDtqOqM3Q68AAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# reload best weights\n",
     "keras_model.load_weights('keras_model_best.h5')\n",
@@ -396,21 +214,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
As discussed with @katilp, I've made some changes to this repo to fix some small issues with the notebook:

- The URL to EOS has changed and needed to be updated
- I cleared the cell output so end-users can run the notebook from scratch
- I added an `environment.yml` file to make the repo compatible with Binder (someone will probably need to update this with the right versions?)
- I also removed the SWAN link in the README and replaced it with Binder (linking directly to the notebook) so that the notebook can be executed openly and anonymously by any user (not just CERN people) without installation
- I added a `.gitignore` to hide all the files generated by `repo2docker` and/or Jupyter
